### PR TITLE
Hotfix : missing initialization

### DIFF
--- a/srcs/http/request/RequestString.cpp
+++ b/srcs/http/request/RequestString.cpp
@@ -61,7 +61,7 @@ size_t	RequestString::getRequestLineString(std::string __reqString)
 
 size_t	RequestString::getHeadersString(std::string __reqString, size_t __requestLineIndex)
 {
-	size_t	index;
+	size_t	index = 0;
 
 	do
 	{

--- a/srcs/http/request/RequestString.cpp
+++ b/srcs/http/request/RequestString.cpp
@@ -61,7 +61,7 @@ size_t	RequestString::getRequestLineString(std::string __reqString)
 
 size_t	RequestString::getHeadersString(std::string __reqString, size_t __requestLineIndex)
 {
-	size_t	index = 0;
+	size_t	index = __requestLineIndex;
 
 	do
 	{


### PR DESCRIPTION
- [x] headers의 끝을 찾을 떄, 시작 지점의 index가 초기화되어 있지 않은 부분을 수정하였습니다.